### PR TITLE
Add installation instructions for fisherman

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ A couple of example journeys:
 
 ## Installation
 
-You need `curl` installed for the interactive package completions.
+**NOTE:** You need `curl` installed for the interactive package completions.
+
+### [Fisherman](https://github.com/fisherman/fisherman)
+
+```fish
+> fisher ohanhi/fish-elm-completions
+```
+
+### Manual
 
 Install by copying or cloning the files under the directory `~/.config/fish/completions/` on your computer. You can may create it if it doesn't exist yet.


### PR DESCRIPTION
Hi, I'm loving using these completions!

I thought you might like to know that I installed these completions using [fisherman](https://github.com/fisherman/fisherman). If you want to let others know, you could write something in the README, or merge this PR.

By the way, as mentioned in [this fisherman issue](https://github.com/fisherman/fisherman/issues/156), although completions is a legitimate use of fisherman, it could also be a good idea to (eventually) submit a PR to [fish-shell/fish-shell](https://github.com/fish-shell/fish-shell/tree/master/share/completions), so everyone who installs fish has elm completions 😃.

Toby