### PR TITLE
Automate Installation Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ A couple of example journeys:
 ### Curl
 
 ```sh
-$ curl -L https://gist.githubusercontent.com/akabiru/bc0b37a322582d9098bffe2f3316a94e/raw/0c2c80244a4bf68c8e0d89d3f4d2ce4904c64d1e/install_fish_elm_completions.fish | fish
+$ curl -L https://raw.githubusercontent.com/ohanhi/fish-elm-completions/master/hooks/install.fish | fish
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A couple of example journeys:
 > elm-pa[TAB] # elm-package
 > elm-package i[TAB] # elm-package install
 > elm-package install ev[TAB] # elm-package install evancz/
-> elm-package install evancz/[TAB] 
+> elm-package install evancz/[TAB]
 [suggestions] evancz/elm-graphics evancz/elm-markdown ...
 ```
 
@@ -24,6 +24,8 @@ A couple of example journeys:
 
 ## Installation
 
-You need `curl` installed for the interactive package completions.
+> You need `curl` installed for the interactive package completions.
 
-Install by copying or cloning the files under the directory `~/.config/fish/completions/` on your computer. You can may create it if it doesn't exist yet.
+```sh
+$ curl -L https://gist.githubusercontent.com/akabiru/bc0b37a322582d9098bffe2f3316a94e/raw/0c2c80244a4bf68c8e0d89d3f4d2ce4904c64d1e/install_fish_elm_completions.fish | fish
+```

--- a/hooks/install.fish
+++ b/hooks/install.fish
@@ -1,0 +1,44 @@
+#!/usr/local/bin/fish
+begin
+  set fish_completions_dir ~/.config/fish/completions
+  set elm_tools 'make' 'package' 'reactor' 'repl' 'test'
+
+  function verify_completions_dir
+    if test -d $fish_completions_dir
+      echo "=> Using existing completions dir $fish_completions_dir..."
+    else
+      echo "=> Creating $fish_completions_dir ..."
+      mkdir -p $fish_completions_dir
+    end
+  end
+
+  function install_elm_completions
+    for tool in $elm_tools
+      set -l t "elm-$tool.fish"
+
+      echo "=> Installing $t..."
+      curl -o "$fish_completions_dir/$t" "https://raw.githubusercontent.com/ohanhi/fish-elm-completions/master/$t"
+
+      print_success_msg "$t completions installed √"
+    end
+
+    print_success_msg "=> Installation complete! √"
+  end
+
+  function print_success_msg
+    set_color green
+    echo $argv
+    set_color normal
+  end
+
+  function main
+    if which curl > /dev/null
+      verify_completions_dir
+      install_elm_completions
+    else
+      echo "=> Dependency Error: please install curl and then try again."
+    end
+  end
+
+  main
+end


### PR DESCRIPTION
This PR aims to automate the installation process with a single `curl` command.

_Edit:_
## Testing
Installation script can be tested out with the following placeholder gist
```sh
$ curl -L https://gist.githubusercontent.com/akabiru/bc0b37a322582d9098bffe2f3316a94e/raw/0c2c80244a4bf68c8e0d89d3f4d2ce4904c64d1e/install_fish_elm_completions.fish | fish
```

ReadMe instructions point to the proposed script on master. 🙂 

Happy to hear your thoughts. Cheers!

![screen shot 2018-01-22 at 22 48 41](https://user-images.githubusercontent.com/17295175/35241128-87036aa6-ffc6-11e7-9af4-974a8c845659.jpg)
