### PR TITLE
Add completion for `elm`

### DIFF
--- a/elm-make.fish
+++ b/elm-make.fish
@@ -1,7 +1,15 @@
-complete -f -c elm-make -l output -a FILE -d 'Write result to the given .html or .js FILE.'
-complete -f -c elm-make -l report -a json -d 'Format of error and warning reports (e.g. --report=json)'
-complete -f -c elm-make -l docs -a docs.json -d 'Write documentation to FILE as JSON.'
-complete -f -c elm-make -l yes -d "Reply 'yes' to all automated prompts."
-complete -f -c elm-make -l debug -d 'Generate programs in debug mode.'
-complete -f -c elm-make -l warn -d 'Report warnings to improve code quality.'
-complete -f -c elm-make -s h -l help -d 'Display help message'
+function __fish_elm_space_or_hyphen_make
+    set cmd (commandline -opc)
+
+    [ "$cmd[1]" =  'elm-make' ]; or [ "$cmd[1..2]" =  'elm make' ]; and return 0
+
+    return 1
+end
+
+complete -c elm -c elm-make -n '__fish_elm_space_or_hyphen_make' -l output -d 'Write result to the given .html or .js FILE.'
+complete -fc elm -c elm-make -n '__fish_elm_space_or_hyphen_make' -l report -a json -d 'Format of error and warning reports (e.g. --report=json)'
+complete -c elm -c elm-make -n '__fish_elm_space_or_hyphen_make' -l docs -a docs.json -d 'Write documentation to FILE as JSON.'
+complete -fc elm -c elm-make -n '__fish_elm_space_or_hyphen_make' -l yes -d "Reply 'yes' to all automated prompts."
+complete -c elm -c elm-make -n '__fish_elm_space_or_hyphen_make' -l debug -d 'Generate programs in debug mode.'
+complete -c elm -c elm-make -n '__fish_elm_space_or_hyphen_make' -l warn -d 'Report warnings to improve code quality.'
+complete -fc elm -c elm-make -n '__fish_elm_space_or_hyphen_make' -s h -l help -d 'Display help message'

--- a/elm-package.fish
+++ b/elm-package.fish
@@ -1,70 +1,57 @@
-# From the npm completions that shipped with fish
-
 function __fish_elm_package_needs_command
     set cmd (commandline -opc)
 
-    if [ (count $cmd) -eq 1 ]
-        return 0
-    end
-
+    [ "$cmd" = 'elm-package' ]; or [ "$cmd" = 'elm package' ]; and return 0
     return 1
 end
 
 function __fish_elm_package_using_command
     set cmd (commandline -opc)
 
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
-            return 0
-        end
-    end
+    [ "$cmd[1..2]" = "elm-package $argv[1]" ]; and return 0
+    [ "$cmd[1..3]" = "elm package $argv[1]" ]; and return 0
 
     return 1
 end
 
 
-# Install
-complete -f -c elm-package -n '__fish_elm_package_needs_command' -a 'install' -d 'Install packages to use locally'
-complete -f -c elm-package -n "__fish_elm_package_using_command install" -s y -l yes -d "Reply 'yes' to all automated prompts."
-complete -f -c elm-package -n "__fish_elm_package_using_command install" -s h -l help -d "Show this help text"
+function __fish_elm_package_all_packages
+    # If $XDG_CACHE_HOME is set, use that directory to save packages cache, otherwise use ~/.cache
+    set -q XDG_CACHE_HOME
+    and set __fish_elm_package_list_path $XDG_CACHE_HOME/elm-packages.txt
+    or set __fish_elm_package_list_path ~/.cache/elm-packages.txt
+    mkdir -p (dirname $__fish_elm_package_list_path)
 
-
-# If $XDG_CACHE_HOME is set, use that directory to save packages cache, otherwise use ~/.cache
-set -q XDG_CACHE_HOME
-and set -g __fish_elm_package_list_path $XDG_CACHE_HOME/elm-packages.txt
-or set -g __fish_elm_package_list_path ~/.cache/elm-packages.txt
-mkdir -p (dirname $__fish_elm_package_list_path)
-
-# Based on https://github.com/eeue56/elm-bash-completion/
-function __fish_fetch_elm_package_list
+    # Based on https://github.com/eeue56/elm-bash-completion/
     set _week_in_secs 604800
     set _current_time (date +%s)
 
+    set _package_list_time 0
     find $__fish_elm_package_list_path 2>/dev/null
     and set _package_list_time (date -r $__fish_elm_package_list_path +%s)
-    or set _package_list_time 0
 
     if math "$_current_time > $_package_list_time + $_week_in_secs"
-        curl 'http://package.elm-lang.org/new-packages' -sS | tr '\n' ' ' | sed -E 's/\s//g' | sed -E 's/"//g' | sed -E 's/,/ /g' | sed -E 's/\[//' | sed -E 's/]//' >$__fish_elm_package_list_path
+        curl 'http://package.elm-lang.org/new-packages' -sS | tr -d ' []",' >$__fish_elm_package_list_path
     end
+
+    # The pipe to tr is for backward-compatibility with older elm-packages.txt
+    cat $__fish_elm_package_list_path | tr ' ' '\n'
 end
 
-__fish_fetch_elm_package_list
-set __fish_elm_package_packages (cat $__fish_elm_package_list_path)
-
-for package in $__fish_elm_package_packages
-    echo $package
-    complete -f -c elm-package -n "__fish_elm_package_using_command install" -a "$package"
-end
+# Install
+complete -fc elm -c elm-package -n '__fish_elm_package_needs_command' -a 'install' -d 'Install packages to use locally'
+complete -fc elm -c elm-package -n "__fish_elm_package_using_command install" -s y -l yes -d "Reply 'yes' to all automated prompts."
+complete -fc elm -c elm-package -n "__fish_elm_package_using_command install" -s h -l help -d "Show this help text"
+complete -fc elm -c elm-package -n "__fish_elm_package_using_command install" -a '(__fish_elm_package_all_packages)'
 
 # Publish
-complete -f -c elm-package -n '__fish_elm_package_needs_command' -a 'publish' -d 'Publish your package to the central catalog'
-complete -f -c elm-package -n "__fish_elm_package_needs_command publish" -s h -l help -d "Show this help text"
+complete -fc elm -c elm-package -n '__fish_elm_package_needs_command' -a 'publish' -d 'Publish your package to the central catalog'
+complete -fc elm -c elm-package -n "__fish_elm_package_needs_command publish" -s h -l help -d "Show this help text"
 
 # Bump
-complete -f -c elm-package -n '__fish_elm_package_needs_command' -a 'bump' -d 'Bump version numbers based on API changes'
-complete -f -c elm-package -n "__fish_elm_package_needs_command bump" -s h -l help -d "Show this help text"
+complete -fc elm -c elm-package -n '__fish_elm_package_needs_command' -a 'bump' -d 'Bump version numbers based on API changes'
+complete -fc elm -c elm-package -n "__fish_elm_package_needs_command bump" -s h -l help -d "Show this help text"
 
 # Diff
-complete -f -c elm-package -n '__fish_elm_package_needs_command' -a 'diff' -d 'Get differences between two APIs'
-complete -f -c elm-package -n "__fish_elm_package_needs_command diff" -s h -l help -d "Show this help text"
+complete -fc elm -c elm-package -n '__fish_elm_package_needs_command' -a 'diff' -d 'Get differences between two APIs'
+complete -fc elm -c elm-package -n "__fish_elm_package_needs_command diff" -s h -l help -d "Show this help text"

--- a/elm-reactor.fish
+++ b/elm-reactor.fish
@@ -1,5 +1,14 @@
-complete -f -c elm-reactor -s a -l address -a 0.0.0.0 -d 'set the address of the server'
-complete -f -c elm-reactor -s p -l port -a 8000 -d 'set the port of the reactor'
-complete -f -c elm-reactor -s h -l help -d 'Display help message'
-complete -f -c elm-reactor -s v -l version -d 'Print version information'
-complete -f -c elm-reactor -l 'numeric-version' -d 'Print just the version number'
+function __fish_elm_space_or_hyphen_reactor
+    set cmd (commandline -opc)
+
+    [ "$cmd[1]" =  'elm-reactor' ]; or [ "$cmd[1..2]" =  'elm reactor' ]; and return 0
+
+    return 1
+end
+
+
+complete -fc elm -c elm-reactor -n '__fish_elm_space_or_hyphen_reactor' -s a -l address -a 0.0.0.0 -d 'set the address of the server'
+complete -fc elm -c elm-reactor -n '__fish_elm_space_or_hyphen_reactor' -s p -l port -a 8000 -d 'set the port of the reactor'
+complete -fc elm -c elm-reactor -n '__fish_elm_space_or_hyphen_reactor' -s h -l help -d 'Display help message'
+complete -fc elm -c elm-reactor -n '__fish_elm_space_or_hyphen_reactor' -s v -l version -d 'Print version information'
+complete -fc elm -c elm-reactor -n '__fish_elm_space_or_hyphen_reactor' -l 'numeric-version' -d 'Print just the version number'

--- a/elm-repl.fish
+++ b/elm-repl.fish
@@ -1,5 +1,13 @@
-complete -f -c elm-repl -s c -l compiler -a FILE -d 'Provide a path to a specific version of elm-make.'
-complete -f -c elm-repl -s i -l interpreter -a node -d 'Provide a path to a specific JavaScript interpreter'
-complete -f -c elm-repl -s h -l help -d 'Display help message'
-complete -f -c elm-repl -s v -l version -d 'Print version information'
-complete -f -c elm-repl -l 'numeric-version' -d 'Print just the version number'
+function __fish_elm_space_or_hyphen_repl
+    set cmd (commandline -opc)
+
+    [ "$cmd[1]" =  'elm-repl' ]; or [ "$cmd[1..2]" =  'elm repl' ]; and return 0
+
+    return 1
+end
+
+complete -fc elm -c elm-repl -n '__fish_elm_space_or_hyphen_repl' -s c -l compiler -a FILE -d 'Provide a path to a specific version of elm-make.'
+complete -fc elm -c elm-repl -n '__fish_elm_space_or_hyphen_repl' -s i -l interpreter -a node -d 'Provide a path to a specific JavaScript interpreter'
+complete -fc elm -c elm-repl -n '__fish_elm_space_or_hyphen_repl' -s h -l help -d 'Display help message'
+complete -fc elm -c elm-repl -n '__fish_elm_space_or_hyphen_repl' -s v -l version -d 'Print version information'
+complete -fc elm -c elm-repl -n '__fish_elm_space_or_hyphen_repl' -l 'numeric-version' -d 'Print just the version number'

--- a/elm-test.fish
+++ b/elm-test.fish
@@ -1,9 +1,17 @@
+function __fish_elm_space_or_hyphen_test_and_not_init
+    set cmd (commandline -opc)
+
+    [ "$cmd[1]" =  'elm-test' ]; and [ "$cmd[1..2]" !=  'elm-test init' ]; and return 0
+    [ "$cmd[1..2]" =  'elm test' ]; and [ "$cmd[1..3]" !=  'elm test init' ]; and return 0
+
+    return 1
+end
+
 function __fish_elm_test_needs_command
     set cmd (commandline -opc)
 
-    if [ (count $cmd) -eq 1 ]
-        return 0
-    end
+    [ (count $cmd) -eq 1 ]; and [ "$cmd[1]" = 'elm-test' ]; and return 0
+    [ (count $cmd) -eq 2 ]; and [ "$cmd[1..2]" = 'elm test' ]; and return 0
 
     return 1
 end
@@ -11,18 +19,19 @@ end
 function __fish_elm_test_using_command
     set cmd (commandline -opc)
 
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
-            return 0
-        end
-    end
+    [ "$cmd[1..2]" = "elm-test $argv[1]" ]; and return 0
+    [ "$cmd[1..3]" = "elm test $argv[1]" ]; and return 0
 
     return 1
 end
 
-complete -f -c elm-test -l compiler -a /path/to/compiler
-complete -f -c elm-test -l seed -a integer -d 'Run with initial fuzzer seed'
-complete -f -c elm-test -l report -a 'json chalk' -d 'Print results to stdout in given format'
-complete -f -c elm-test -l watch -d 'Run tests on file changes'
-complete -f -c elm-test -n '__fish_elm_test_needs_command' -a init -d 'Create example tests'
-complete -f -c elm-test -n "__fish_elm_test_using_command init" -l yes -d "Reply 'yes' to all automated prompts."
+complete -c elm -c elm-test -n '__fish_elm_space_or_hyphen_test_and_not_init' -l compiler -d 'Specify path to compiler'
+complete -fc elm -c elm-test -n '__fish_elm_space_or_hyphen_test_and_not_init' -l seed -d 'Run with initial fuzzer seed (an integer)'
+complete -fc elm -c elm-test -n '__fish_elm_space_or_hyphen_test_and_not_init' -l fuzz -a '(seq 1 50)' -d 'Run with each fuzz test performing this many interations'
+complete -c elm -c elm-test -n '__fish_elm_space_or_hyphen_test_and_not_init' -l add-dependencies -d 'Add missing dependencies from current elm-package.json to destination'
+complete -fc elm -c elm-test -n '__fish_elm_space_or_hyphen_test_and_not_init' -l report -a 'json junit console' -d 'Print results to stdout in given format (default: console)'
+complete -c elm -c elm-test -n '__fish_elm_space_or_hyphen_test_and_not_init' -l version -d 'Print version string and exit'
+complete -c elm -c elm-test -n '__fish_elm_space_or_hyphen_test_and_not_init' -s h -l help -d 'Print elm-test usage'
+complete -c elm -c elm-test -n '__fish_elm_space_or_hyphen_test_and_not_init' -l watch -d 'Run tests on file changes'
+complete -fc elm -c elm-test -n '__fish_elm_test_needs_command' -a init -d 'Create example tests'
+complete -fc elm -c elm-test -n '__fish_elm_test_using_command init' -l yes -d "Reply 'yes' to all automated prompts."

--- a/elm.fish
+++ b/elm.fish
@@ -1,0 +1,12 @@
+function __fish_elm_needs_command
+    set cmd (commandline -opc)
+
+    if [ (count $cmd) -eq 1 ]
+        return 0
+    end
+
+    return 1
+end
+
+complete -fc elm -n '__fish_elm_needs_command' -a '(string replace -r "^.*/elm-([^/]*)" \'$1\' $PATH/elm-*)'
+complete -fc elm -n '__fish_elm_needs_command' -s v -l version -d 'Print version number'

--- a/hooks/install.fish
+++ b/hooks/install.fish
@@ -1,7 +1,7 @@
 #!/usr/local/bin/fish
 begin
   set fish_completions_dir ~/.config/fish/completions
-  set elm_tools 'make' 'package' 'reactor' 'repl' 'test'
+  set elm_tools 'elm' 'elm-make' 'elm-package' 'elm-reactor' 'elm-repl' 'elm-test'
 
   function verify_completions_dir
     if test -d $fish_completions_dir
@@ -14,7 +14,7 @@ begin
 
   function install_elm_completions
     for tool in $elm_tools
-      set -l t "elm-$tool.fish"
+      set -l t "$tool.fish"
 
       echo "=> Installing $t..."
       curl -o "$fish_completions_dir/$t" "https://raw.githubusercontent.com/ohanhi/fish-elm-completions/master/$t"


### PR DESCRIPTION
This PR adds basic completion for `elm`. It looks for all `elm-*` commands, so it can complete commands that don't currently have full completion, like [`elm-github-install`](https://github.com/gdotdesign/elm-github-install) or [`elm-help`](https://github.com/eeue56/elm-help). It also adds completions for `-v` and `--version`. I don't think there are any other basic commands/flags you can give elm?

Obviously it would be great to have all the completions for, say, `elm package` that `elm-package` has, but I don't think there's a particularly elegant way to do that, and it would require lots of changes over all files, which I wasn't going to just do without discussing first.

This is very basic at the moment, so I appreciate may not want to merge this into `master` just yet.